### PR TITLE
Fix ETS leak on process death

### DIFF
--- a/src/rfc4627_jsonrpc_registry.erl
+++ b/src/rfc4627_jsonrpc_registry.erl
@@ -85,7 +85,7 @@ handle_info({'DOWN', _MonitorRef, process, DownPid, _Reason}, State) ->
     case ets:lookup(?TABLE_NAME, {service_pid, DownPid}) of
         [] ->
             {noreply, State};
-        [ServiceName] ->
+        [{_, ServiceName}] ->
             ets:delete(?TABLE_NAME, {service_pid, DownPid}),
             ets:delete(?TABLE_NAME, {service, ServiceName}),
             {noreply, State}


### PR DESCRIPTION
There's a tiny little leak here since ets:lookup/2 returns the entire row.

Well, one of our users got it up to 18GB... o_O.
