### PR TITLE
Avoid use of non-dfsg-free json.js

### DIFF
--- a/test/server_root/htdocs/json.js
+++ b/test/server_root/htdocs/json.js
@@ -1,381 +1,482 @@
 /*
-Copyright (c) 2005 JSON.org
-Copyright (c) 2005, 2006 tonyg@kcbbs.gen.nz
+    http://www.JSON.org/json2.js
+    2010-08-25
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+    Public Domain.
 
-The Software shall be used for Good, not Evil.
+    NO WARRANTY EXPRESSED OR IMPLIED. USE AT YOUR OWN RISK.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+    See http://www.JSON.org/js.html
 
 
-CHANGELOG
-=========
+    This code should be minified before deployment.
+    See http://javascript.crockford.com/jsmin.html
 
- - September 2005: changes by tonyg@kcbbs.gen.nz for constructors and
-   customisable serialisation
+    USE YOUR OWN COPY. IT IS EXTREMELY UNWISE TO LOAD CODE FROM SERVERS YOU DO
+    NOT CONTROL.
 
- - 23 June 2006: changes by tonyg@kcbbs.gen.nz for Rhino JS support
- - 24 June 2006: changes by tonyg@kcbbs.gen.nz for better array-detection
- - 8 November 2006: tonyg: conditionalise Java-specific code
 
+    This file creates a global JSON object containing two methods: stringify
+    and parse.
+
+        JSON.stringify(value, replacer, space)
+            value       any JavaScript value, usually an object or array.
+
+            replacer    an optional parameter that determines how object
+                        values are stringified for objects. It can be a
+                        function or an array of strings.
+
+            space       an optional parameter that specifies the indentation
+                        of nested structures. If it is omitted, the text will
+                        be packed without extra whitespace. If it is a number,
+                        it will specify the number of spaces to indent at each
+                        level. If it is a string (such as '\t' or '&nbsp;'),
+                        it contains the characters used to indent at each level.
+
+            This method produces a JSON text from a JavaScript value.
+
+            When an object value is found, if the object contains a toJSON
+            method, its toJSON method will be called and the result will be
+            stringified. A toJSON method does not serialize: it returns the
+            value represented by the name/value pair that should be serialized,
+            or undefined if nothing should be serialized. The toJSON method
+            will be passed the key associated with the value, and this will be
+            bound to the value
+
+            For example, this would serialize Dates as ISO strings.
+
+                Date.prototype.toJSON = function (key) {
+                    function f(n) {
+                        // Format integers to have at least two digits.
+                        return n < 10 ? '0' + n : n;
+                    }
+
+                    return this.getUTCFullYear()   + '-' +
+                         f(this.getUTCMonth() + 1) + '-' +
+                         f(this.getUTCDate())      + 'T' +
+                         f(this.getUTCHours())     + ':' +
+                         f(this.getUTCMinutes())   + ':' +
+                         f(this.getUTCSeconds())   + 'Z';
+                };
+
+            You can provide an optional replacer method. It will be passed the
+            key and value of each member, with this bound to the containing
+            object. The value that is returned from your method will be
+            serialized. If your method returns undefined, then the member will
+            be excluded from the serialization.
+
+            If the replacer parameter is an array of strings, then it will be
+            used to select the members to be serialized. It filters the results
+            such that only members with keys listed in the replacer array are
+            stringified.
+
+            Values that do not have JSON representations, such as undefined or
+            functions, will not be serialized. Such values in objects will be
+            dropped; in arrays they will be replaced with null. You can use
+            a replacer function to replace those with JSON values.
+            JSON.stringify(undefined) returns undefined.
+
+            The optional space parameter produces a stringification of the
+            value that is filled with line breaks and indentation to make it
+            easier to read.
+
+            If the space parameter is a non-empty string, then that string will
+            be used for indentation. If the space parameter is a number, then
+            the indentation will be that many spaces.
+
+            Example:
+
+            text = JSON.stringify(['e', {pluribus: 'unum'}]);
+            // text is '["e",{"pluribus":"unum"}]'
+
+
+            text = JSON.stringify(['e', {pluribus: 'unum'}], null, '\t');
+            // text is '[\n\t"e",\n\t{\n\t\t"pluribus": "unum"\n\t}\n]'
+
+            text = JSON.stringify([new Date()], function (key, value) {
+                return this[key] instanceof Date ?
+                    'Date(' + this[key] + ')' : value;
+            });
+            // text is '["Date(---current time---)"]'
+
+
+        JSON.parse(text, reviver)
+            This method parses a JSON text to produce an object or array.
+            It can throw a SyntaxError exception.
+
+            The optional reviver parameter is a function that can filter and
+            transform the results. It receives each of the keys and values,
+            and its return value is used instead of the original value.
+            If it returns what it received, then the structure is not modified.
+            If it returns undefined then the member is deleted.
+
+            Example:
+
+            // Parse the text. Values that look like ISO date strings will
+            // be converted to Date objects.
+
+            myData = JSON.parse(text, function (key, value) {
+                var a;
+                if (typeof value === 'string') {
+                    a =
+/^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2}(?:\.\d*)?)Z$/.exec(value);
+                    if (a) {
+                        return new Date(Date.UTC(+a[1], +a[2] - 1, +a[3], +a[4],
+                            +a[5], +a[6]));
+                    }
+                }
+                return value;
+            });
+
+            myData = JSON.parse('["Date(09/09/2001)"]', function (key, value) {
+                var d;
+                if (typeof value === 'string' &&
+                        value.slice(0, 5) === 'Date(' &&
+                        value.slice(-1) === ')') {
+                    d = new Date(value.slice(5, -1));
+                    if (d) {
+                        return d;
+                    }
+                }
+                return value;
+            });
+
+
+    This is a reference implementation. You are free to copy, modify, or
+    redistribute.
 */
 
-var JSON = {
-    org: 'http://www.JSON.org',
-    copyright: '(c)2005 JSON.org',
-    license: 'http://www.crockford.com/JSON/license.html',
+/*jslint evil: true, strict: false */
 
-    javaSerializers: {
-	"java.lang.Object": function (arg) { return JSON.stringify(String(arg)); }
-    },
+/*members "", "\b", "\t", "\n", "\f", "\r", "\"", JSON, "\\", apply,
+    call, charCodeAt, getUTCDate, getUTCFullYear, getUTCHours,
+    getUTCMinutes, getUTCMonth, getUTCSeconds, hasOwnProperty, join,
+    lastIndex, length, parse, prototype, push, replace, slice, stringify,
+    test, toJSON, toString, valueOf
+*/
 
-    rhinoSupport: false, /* set to true to enable Java JSON serialization */
-    isJavaObject: function (o) {
-	if (this.rhinoSupport) {
-	    if (o instanceof java.lang.Object) {
-		return true;
-	    }
-	}
-	return false;
-    },
 
-    findJavaSerializer: function (o) {
-	var c = o.getClass();
-	while (c != null) {
-	    if (typeof this.javaSerializers[c.getName()] != 'undefined') {
-		return this.javaSerializers[c.getName()];
-	    }
-	    var interfaces = c.getInterfaces();
-	    for (var i = 0; i < interfaces.length; i++) {
-		if (typeof this.javaSerializers[interfaces[i].getName()] != 'undefined') {
-		    return this.javaSerializers[interfaces[i].getName()];
-		}
-	    }
-	    c = c.getSuperclass();
-	}
-	return null;
-    },
+// Create a JSON object only if one does not already exist. We create the
+// methods in a closure to avoid creating global variables.
 
-    stringify: function (arg) {
-        var c, i, l, s = '', v;
+if (!this.JSON) {
+    this.JSON = {};
+}
 
-        switch (typeof arg) {
-        case 'object':
-            if (arg) {
-                if (arg instanceof Array) {
-                    for (i = 0; i < arg.length; ++i) {
-                        v = this.stringify(arg[i]);
-                        if (s) {
-                            s += ',';
-                        }
-                        s += v;
-                    }
-                    return '[' + s + ']';
-		} else if (typeof arg.toJsonString != 'undefined') {
-		    return arg.toJsonString();
-		} else if (this.isJavaObject(arg)) {
-		    v = this.findJavaSerializer(arg);
-		    if (v != null) {
-			return v(arg);
-		    }
-                } else if (typeof arg.toString != 'undefined') {
-                    for (i in arg) {
-                        v = arg[i];
-                        if (typeof v != 'undefined' && typeof v != 'function') {
-                            v = this.stringify(v);
-                            if (s) {
-                                s += ',';
-                            }
-                            s += this.stringify(i) + ':' + v;
-                        }
-                    }
-                    return '{' + s + '}';
-                }
-            }
-            return 'null';
-        case 'number':
-            return isFinite(arg) ? String(arg) : 'null';
+(function () {
+
+    function f(n) {
+        // Format integers to have at least two digits.
+        return n < 10 ? '0' + n : n;
+    }
+
+    if (typeof Date.prototype.toJSON !== 'function') {
+
+        Date.prototype.toJSON = function (key) {
+
+            return isFinite(this.valueOf()) ?
+                   this.getUTCFullYear()   + '-' +
+                 f(this.getUTCMonth() + 1) + '-' +
+                 f(this.getUTCDate())      + 'T' +
+                 f(this.getUTCHours())     + ':' +
+                 f(this.getUTCMinutes())   + ':' +
+                 f(this.getUTCSeconds())   + 'Z' : null;
+        };
+
+        String.prototype.toJSON =
+        Number.prototype.toJSON =
+        Boolean.prototype.toJSON = function (key) {
+            return this.valueOf();
+        };
+    }
+
+    var cx = /[\u0000\u00ad\u0600-\u0604\u070f\u17b4\u17b5\u200c-\u200f\u2028-\u202f\u2060-\u206f\ufeff\ufff0-\uffff]/g,
+        escapable = /[\\\"\x00-\x1f\x7f-\x9f\u00ad\u0600-\u0604\u070f\u17b4\u17b5\u200c-\u200f\u2028-\u202f\u2060-\u206f\ufeff\ufff0-\uffff]/g,
+        gap,
+        indent,
+        meta = {    // table of character substitutions
+            '\b': '\\b',
+            '\t': '\\t',
+            '\n': '\\n',
+            '\f': '\\f',
+            '\r': '\\r',
+            '"' : '\\"',
+            '\\': '\\\\'
+        },
+        rep;
+
+
+    function quote(string) {
+
+// If the string contains no control characters, no quote characters, and no
+// backslash characters, then we can safely slap some quotes around it.
+// Otherwise we must also replace the offending characters with safe escape
+// sequences.
+
+        escapable.lastIndex = 0;
+        return escapable.test(string) ?
+            '"' + string.replace(escapable, function (a) {
+                var c = meta[a];
+                return typeof c === 'string' ? c :
+                    '\\u' + ('0000' + a.charCodeAt(0).toString(16)).slice(-4);
+            }) + '"' :
+            '"' + string + '"';
+    }
+
+
+    function str(key, holder) {
+
+// Produce a string from holder[key].
+
+        var i,          // The loop counter.
+            k,          // The member key.
+            v,          // The member value.
+            length,
+            mind = gap,
+            partial,
+            value = holder[key];
+
+// If the value has a toJSON method, call it to obtain a replacement value.
+
+        if (value && typeof value === 'object' &&
+                typeof value.toJSON === 'function') {
+            value = value.toJSON(key);
+        }
+
+// If we were called with a replacer function, then call the replacer to
+// obtain a replacement value.
+
+        if (typeof rep === 'function') {
+            value = rep.call(holder, key, value);
+        }
+
+// What happens next depends on the value's type.
+
+        switch (typeof value) {
         case 'string':
-            l = arg.length;
-            s = '"';
-            for (i = 0; i < l; i += 1) {
-                c = arg.charAt(i);
-                if (c >= ' ') {
-                    if (c == '\\' || c == '"') {
-                        s += '\\';
-                    }
-                    s += c;
-                } else {
-                    switch (c) {
-                        case '\b':
-                            s += '\\b';
-                            break;
-                        case '\f':
-                            s += '\\f';
-                            break;
-                        case '\n':
-                            s += '\\n';
-                            break;
-                        case '\r':
-                            s += '\\r';
-                            break;
-                        case '\t':
-                            s += '\\t';
-                            break;
-                        default:
-                            c = c.charCodeAt();
-                            s += '\\u00' + Math.floor(c / 16).toString(16) +
-                                (c % 16).toString(16);
-                    }
-                }
-            }
-            return s + '"';
+            return quote(value);
+
+        case 'number':
+
+// JSON numbers must be finite. Encode non-finite numbers as null.
+
+            return isFinite(value) ? String(value) : 'null';
+
         case 'boolean':
-            return String(arg);
-        default:
-            return 'null';
-        }
-    },
-    parse: function (text, ctors) {
-        var at = 0;
-        var ch = ' ';
+        case 'null':
 
-        function error(m) {
-            throw {
-                name: 'JSONError',
-                message: m,
-                at: at - 1,
-                text: text
-            };
-        }
+// If the value is a boolean or null, convert it to a string. Note:
+// typeof null does not produce 'null'. The case is included here in
+// the remote chance that this gets fixed someday.
 
-        function next() {
-            ch = text.charAt(at);
-            at += 1;
-            return ch;
-        }
+            return String(value);
 
-        function white() {
-            while (ch != '' && ch <= ' ') {
-                next();
+// If the type is 'object', we might be dealing with an object or an array or
+// null.
+
+        case 'object':
+
+// Due to a specification blunder in ECMAScript, typeof null is 'object',
+// so watch out for that case.
+
+            if (!value) {
+                return 'null';
             }
-        }
 
-        function str() {
-            var i, s = '', t, u;
+// Make an array to hold the partial results of stringifying this object value.
 
-            if (ch == '"') {
-outer:          while (next()) {
-                    if (ch == '"') {
-                        next();
-                        return s;
-                    } else if (ch == '\\') {
-                        switch (next()) {
-                        case 'b':
-                            s += '\b';
-                            break;
-                        case 'f':
-                            s += '\f';
-                            break;
-                        case 'n':
-                            s += '\n';
-                            break;
-                        case 'r':
-                            s += '\r';
-                            break;
-                        case 't':
-                            s += '\t';
-                            break;
-                        case 'u':
-                            u = 0;
-                            for (i = 0; i < 4; i += 1) {
-                                t = parseInt(next(), 16);
-                                if (!isFinite(t)) {
-                                    break outer;
-                                }
-                                u = u * 16 + t;
-                            }
-                            s += String.fromCharCode(u);
-                            break;
-                        default:
-                            s += ch;
-                        }
-                    } else {
-                        s += ch;
-                    }
-                }
-            }
-            error("Bad string");
-        }
+            gap += indent;
+            partial = [];
 
-        function arr() {
-            var a = [];
+// Is the value an array?
 
-            if (ch == '[') {
-                next();
-                white();
-                if (ch == ']') {
-                    next();
-                    return a;
-                }
-                while (ch) {
-                    a.push(val());
-                    white();
-                    if (ch == ']') {
-                        next();
-                        return a;
-                    } else if (ch != ',') {
-                        break;
-                    }
-                    next();
-                    white();
-                }
-            }
-            error("Bad array");
-        }
+            if (Object.prototype.toString.apply(value) === '[object Array]') {
 
-        function obj() {
-            var k, o = {};
+// The value is an array. Stringify every element. Use null as a placeholder
+// for non-JSON values.
 
-            if (ch == '{') {
-                next();
-                white();
-                if (ch == '}') {
-                    next();
-                    return o;
+                length = value.length;
+                for (i = 0; i < length; i += 1) {
+                    partial[i] = str(i, value) || 'null';
                 }
-                while (ch) {
-                    k = str();
-                    white();
-                    if (ch != ':') {
-                        break;
-                    }
-                    next();
-                    o[k] = val();
-                    white();
-                    if (ch == '}') {
-                        next();
-                        return o;
-                    } else if (ch != ',') {
-                        break;
-                    }
-                    next();
-                    white();
-                }
-            }
-            error("Bad object");
-        }
 
-        function num() {
-            var n = '', v;
-            if (ch == '-') {
-                n = '-';
-                next();
-            }
-            while (ch >= '0' && ch <= '9') {
-                n += ch;
-                next();
-            }
-            if (ch == '.') {
-                n += '.';
-                while (next() && ch >= '0' && ch <= '9') {
-                    n += ch;
-                }
-            }
-            if (ch == 'e' || ch == 'E') {
-                n += 'e';
-                next();
-                if (ch == '-' || ch == '+') {
-                    n += ch;
-                    next();
-                }
-                while (ch >= '0' && ch <= '9') {
-                    n += ch;
-                    next();
-                }
-            }
-            v = +n;
-            if (!isFinite(v)) {
-                error("Bad number");
-            } else {
+// Join all of the elements together, separated with commas, and wrap them in
+// brackets.
+
+                v = partial.length === 0 ? '[]' :
+                    gap ? '[\n' + gap +
+                            partial.join(',\n' + gap) + '\n' +
+                                mind + ']' :
+                          '[' + partial.join(',') + ']';
+                gap = mind;
                 return v;
             }
-        }
 
-        function word() {
-            switch (ch) {
-                case 't':
-                    if (next() == 'r' && next() == 'u' && next() == 'e') {
-                        next();
-                        return true;
+// If the replacer is an array, use it to select the members to be stringified.
+
+            if (rep && typeof rep === 'object') {
+                length = rep.length;
+                for (i = 0; i < length; i += 1) {
+                    k = rep[i];
+                    if (typeof k === 'string') {
+                        v = str(k, value);
+                        if (v) {
+                            partial.push(quote(k) + (gap ? ': ' : ':') + v);
+                        }
                     }
-                    break;
-                case 'f':
-                    if (next() == 'a' && next() == 'l' && next() == 's' &&
-                            next() == 'e') {
-                        next();
-                        return false;
+                }
+            } else {
+
+// Otherwise, iterate through all of the keys in the object.
+
+                for (k in value) {
+                    if (Object.hasOwnProperty.call(value, k)) {
+                        v = str(k, value);
+                        if (v) {
+                            partial.push(quote(k) + (gap ? ': ' : ':') + v);
+                        }
                     }
-                    break;
-                case 'n':
-                    if (next() == 'u' && next() == 'l' && next() == 'l') {
-                        next();
-                        return null;
-                    }
-                    break;
+                }
             }
-            error("Syntax error");
+
+// Join all of the member texts together, separated with commas,
+// and wrap them in braces.
+
+            v = partial.length === 0 ? '{}' :
+                gap ? '{\n' + gap + partial.join(',\n' + gap) + '\n' +
+                        mind + '}' : '{' + partial.join(',') + '}';
+            gap = mind;
+            return v;
         }
-
-	function ctor() {
-	    var name = '';
-	    if (ch == '@') {
-		next();
-		while (ch == '.' || (ch.toUpperCase() >= 'A' &&
-				     ch.toUpperCase() <= 'Z')) {
-		    name += ch;
-		    next();
-		}
-		var arg = val();
-		if (name in ctors) {
-		    return ctors[name](arg);
-		} else {
-		    error("Unknown ctor " + name);
-		}
-	    }
-	    error("Bad ctor");
-	}
-
-        function val() {
-            white();
-            switch (ch) {
-	        case '@':
-		    return ctor();
-                case '{':
-                    return obj();
-                case '[':
-                    return arr();
-                case '"':
-                    return str();
-                case '-':
-                    return num();
-                default:
-                    return ch >= '0' && ch <= '9' ? num() : word();
-            }
-        }
-
-        return val();
     }
-};
+
+// If the JSON object does not yet have a stringify method, give it one.
+
+    if (typeof JSON.stringify !== 'function') {
+        JSON.stringify = function (value, replacer, space) {
+
+// The stringify method takes a value and an optional replacer, and an optional
+// space parameter, and returns a JSON text. The replacer can be a function
+// that can replace values, or an array of strings that will select the keys.
+// A default replacer method can be provided. Use of the space parameter can
+// produce text that is more easily readable.
+
+            var i;
+            gap = '';
+            indent = '';
+
+// If the space parameter is a number, make an indent string containing that
+// many spaces.
+
+            if (typeof space === 'number') {
+                for (i = 0; i < space; i += 1) {
+                    indent += ' ';
+                }
+
+// If the space parameter is a string, it will be used as the indent string.
+
+            } else if (typeof space === 'string') {
+                indent = space;
+            }
+
+// If there is a replacer, it must be a function or an array.
+// Otherwise, throw an error.
+
+            rep = replacer;
+            if (replacer && typeof replacer !== 'function' &&
+                    (typeof replacer !== 'object' ||
+                     typeof replacer.length !== 'number')) {
+                throw new Error('JSON.stringify');
+            }
+
+// Make a fake root object containing our value under the key of ''.
+// Return the result of stringifying the value.
+
+            return str('', {'': value});
+        };
+    }
+
+
+// If the JSON object does not yet have a parse method, give it one.
+
+    if (typeof JSON.parse !== 'function') {
+        JSON.parse = function (text, reviver) {
+
+// The parse method takes a text and an optional reviver function, and returns
+// a JavaScript value if the text is a valid JSON text.
+
+            var j;
+
+            function walk(holder, key) {
+
+// The walk method is used to recursively walk the resulting structure so
+// that modifications can be made.
+
+                var k, v, value = holder[key];
+                if (value && typeof value === 'object') {
+                    for (k in value) {
+                        if (Object.hasOwnProperty.call(value, k)) {
+                            v = walk(value, k);
+                            if (v !== undefined) {
+                                value[k] = v;
+                            } else {
+                                delete value[k];
+                            }
+                        }
+                    }
+                }
+                return reviver.call(holder, key, value);
+            }
+
+
+// Parsing happens in four stages. In the first stage, we replace certain
+// Unicode characters with escape sequences. JavaScript handles many characters
+// incorrectly, either silently deleting them, or treating them as line endings.
+
+            text = String(text);
+            cx.lastIndex = 0;
+            if (cx.test(text)) {
+                text = text.replace(cx, function (a) {
+                    return '\\u' +
+                        ('0000' + a.charCodeAt(0).toString(16)).slice(-4);
+                });
+            }
+
+// In the second stage, we run the text against regular expressions that look
+// for non-JSON patterns. We are especially concerned with '()' and 'new'
+// because they can cause invocation, and '=' because it can cause mutation.
+// But just to be safe, we want to reject all unexpected forms.
+
+// We split the second stage into 4 regexp operations in order to work around
+// crippling inefficiencies in IE's and Safari's regexp engines. First we
+// replace the JSON backslash pairs with '@' (a non-JSON character). Second, we
+// replace all simple value tokens with ']' characters. Third, we delete all
+// open brackets that follow a colon or comma or that begin the text. Finally,
+// we look to see that the remaining characters are only whitespace or ']' or
+// ',' or ':' or '{' or '}'. If that is so, then the text is safe for eval.
+
+            if (/^[\],:{}\s]*$/
+.test(text.replace(/\\(?:["\\\/bfnrt]|u[0-9a-fA-F]{4})/g, '@')
+.replace(/"[^"\\\n\r]*"|true|false|null|-?\d+(?:\.\d*)?(?:[eE][+\-]?\d+)?/g, ']')
+.replace(/(?:^|:|,)(?:\s*\[)+/g, ''))) {
+
+// In the third stage we use the eval function to compile the text into a
+// JavaScript structure. The '{' operator is subject to a syntactic ambiguity
+// in JavaScript: it can begin a block or an object literal. We wrap the text
+// in parens to eliminate the ambiguity.
+
+                j = eval('(' + text + ')');
+
+// In the optional fourth stage, we recursively walk the new structure, passing
+// each name/value pair to a reviver function for possible transformation.
+
+                return typeof reviver === 'function' ?
+                    walk({'': j}, '') : j;
+            }
+
+// If the text is not JSON parseable, then a SyntaxError is thrown.
+
+            throw new SyntaxError('JSON.parse');
+        };
+    }
+}());


### PR DESCRIPTION
I've replaced json.js which Debian are objecting to (http://bugs.debian.org/cgi-bin/bugreport.cgi?bug=692621) with json2.js, which is public domain.

This wipes out a bunch of customisations relating to Java / Rhino that you had made to json.js, but as far as I could see they did not get used by anything in this repo.
